### PR TITLE
fix print formatting

### DIFF
--- a/tools/ztester_beacon.c
+++ b/tools/ztester_beacon.c
@@ -120,12 +120,12 @@ node_actor (zsock_t *pipe, void *args)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zyre_whispers (node, to_peer, "%lld", counter++);
+                zyre_whispers (node, to_peer, "%jd", counter++);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zyre_shouts (node, to_group, "%lld", counter++);
+                zyre_shouts (node, to_group, "%jd", counter++);
                 free (to_group);
                 to_group = NULL;
             }

--- a/tools/ztester_gossip.c
+++ b/tools/ztester_gossip.c
@@ -126,12 +126,12 @@ node_actor (zsock_t *pipe, void *args)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zyre_whispers (node, to_peer, "%lld", counter++);
+                zyre_whispers (node, to_peer, "%jd", counter++);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zyre_shouts (node, to_group, "%lld", counter++);
+                zyre_shouts (node, to_group, "%jd", counter++);
                 free (to_group);
                 to_group = NULL;
             }


### PR DESCRIPTION
`%lld` cannot be used with `int64_t`
